### PR TITLE
Adds a new file demoing asking the same question about different benefits

### DIFF
--- a/docassemble/DeadBrokeDads/data/questions/DBD-test.yml
+++ b/docassemble/DeadBrokeDads/data/questions/DBD-test.yml
@@ -9,11 +9,47 @@ code: |
   
   # only ask about benefits if any listed
   your_past_benefits.there_are_any = len(your_true_benefits) > 0
+  
+  # force the start date before asking about children
+  if your_past_benefits.there_are_any:
+    for item in your_true_benefits:
+      benefit = your_past_benefits[item]
+
+      if benefit.still_receiving:
+        # this should not be visible;
+        benefit.end = today()
+      else:
+        benefit.end = benefit.end_date
+
+        
 
   # same as above
   your_children_true_benefits = your_children_income_list.true_values()
   your_children_past_benefits.there_are_any = len(your_children_true_benefits) > 0
     
+  if your_children_past_benefits.there_are_any:
+    for item in your_children_true_benefits:
+      benefit = your_children_past_benefits[item]
+
+      if benefit.still_receiving:
+        # this should not be visible;
+        benefit.end = today()
+      else:
+        benefit.end = benefit.end_date
+ 
+  if dor_took_money:
+    took_money_matches_time = False
+    
+    # find if the date is in range for your benefits
+    for benefit in your_past_benefits.values():
+      # not sure if end date is inclusive (it counts) or exclusive (it doesn't)
+      if benefit.start_date <= dor_took_money_date <= benefit.end:
+        took_money_matches_time = True
+
+    # find if the date is in range for your child(ren)'s benefits
+    for benefit in your_children_past_benefits.values():
+      if benefit.start_date <= dor_took_money_date <= benefit.end:
+        took_money_matches_time = True    
   hi
 ---
 code: |
@@ -22,8 +58,7 @@ code: |
   # from your_true_benefits
   
   if len(your_past_benefits) < len(your_true_benefits):
-    next_item = your_true_benefits[len(your_past_benefits)].upper()
-    your_past_benefits.new_item_name = next_item
+    your_past_benefits.new_item_name = your_true_benefits[len(your_past_benefits)]
     
     # say that we expect another field (will ask for necessary fields)
     your_past_benefits.there_is_another = True      
@@ -33,8 +68,7 @@ code: |
 ---
 code: |
   if len(your_children_past_benefits) < len(your_children_true_benefits):
-    next_item = your_children_true_benefits[len(your_children_past_benefits)].upper()
-    your_children_past_benefits.new_item_name = next_item
+    your_children_past_benefits.new_item_name = your_children_true_benefits[len(your_children_past_benefits)]
     
     your_children_past_benefits.there_is_another = True
   else:
@@ -46,9 +80,9 @@ fields:
   - no label: your_income_list
     datatype: checkboxes
     choices:
-      - SSI: ssi
-      - TAFDC: tafdc
-      - EAEDC: eaedc
+      - SSI
+      - TAFDC
+      - EAEDC
 ---
 question: |
   About your ${ i } benefit
@@ -61,13 +95,12 @@ fields:
     datatype: date
     js show if: |
       val("your_past_benefits[i].still_receiving") === false
----
-need: your_past_benefits[i].start_date
-question: |
-  Did DOR take money from your bank account when you were getting ${ i }?
-fields:
-  - no label: your_past_benefits[i].take_money
-    datatype: yesnoradio
+validation code: |
+  if your_past_benefits[i].start_date > today():
+    validation_error("Start date cannot be in the future")
+    
+  if not your_past_benefits[i].still_receiving and your_past_benefits[i].start_date > your_past_benefits[i].end_date:
+    validation_error("Benefit end date should be after start date")
 ---
 question: |
   Did your children ever get any of these benefits?
@@ -75,9 +108,9 @@ fields:
   - no label: your_children_income_list
     datatype: checkboxes
     choices:
-      - SSI: ssi
-      - TAFDC: tafdc
-      - EAEDC: eaedc
+      - SSI
+      - TAFDC
+      - EAEDC
 ---
 question: |
   About your child(ren)'s ${ i } benefit
@@ -90,24 +123,41 @@ fields:
     datatype: date
     js show if: |
       val("your_children_past_benefits[i].still_receiving") === false
+validation code: |
+  if your_children_past_benefits[i].start_date > today():
+    validation_error("Start date cannot be in the future")
+    
+  if not your_children_past_benefits[i].still_receiving and your_children_past_benefits[i].start_date > your_children_past_benefits[i].end_date:
+    validation_error("Benefit end date should be after start date")
 ---
-need: your_children_past_benefits[i].start_date
 question: |
-  Did DOR take money from your bank account when your children were getting ${ i }?
+  Has DOR taken money from your bank account?
 fields:
-  - no label: your_children_past_benefits[i].take_money
+  - no label: dor_took_money
     datatype: yesnoradio
+  - "When did DOR Take money from your account?": dor_took_money_date
+    datatype: date
+    show if: dor_took_money
 ---
 question: |
   Hi
-subquestion: |
-  Your past benefits:
+subquestion: |  
+  % if dor_took_money:
+  ### DOR Notice
+  You said DOR took money from your bank ${ dor_took_money_date }.
+  
+    % if took_money_matches_time:
+    DOR took money from your account while you were receiving a benefit.
+    % endif
+  % endif
+  
+  ### Your past benefits:
   % for item in your_past_benefits:
-  ${ item } : ${ your_past_benefits[item].take_money }, ${ your_past_benefits[item].start_date }
+  ${ item } : ${ your_past_benefits[item].start_date } --  ${ your_past_benefits[item].end }<br>
   % endfor
   
-  Your children's past benefits
+  ### Your children's past benefits:
   % for item in your_children_past_benefits:
-  ${ item } : ${ your_children_past_benefits[item].take_money }
+  ${ item } : ${ your_children_past_benefits[item].start_date } -- ${ your_children_past_benefits[item].end } <br>
   % endfor
 field: hi

--- a/docassemble/DeadBrokeDads/data/questions/DBD-test.yml
+++ b/docassemble/DeadBrokeDads/data/questions/DBD-test.yml
@@ -1,0 +1,155 @@
+objects:
+  - your_past_benefits: DADict.using(object_type=DAObject)
+  - your_children_past_benefits: DADict.using(object_type=DAObject)
+---
+mandatory: True
+code: |
+  if past_benefits:
+    # get a list of true benefits; we save this so the order is the same
+    your_true_benefits = past_income_items_list.true_values()
+    
+    # say that there are benefits (forces asking questions)
+    your_past_benefits.there_are_any = True
+  else:
+    # no past benefits, the dictionary should be empty
+    your_past_benefits.there_are_any = False
+  
+  # same as above
+  if past_child_benefits:
+    your_children_true_benefits = past_child_income_items_list.true_values()
+    your_children_past_benefits.there_are_any = True
+  else:
+    your_children_past_benefits.there_are_any = False
+    
+  hi
+---
+code: |
+  # ask for every value in true_benefits in a pseudo-loop.
+  # every time this code executes, we add one item to your_past_benefits
+  # from your_true_benefits
+  
+  if len(your_past_benefits) < len(your_true_benefits):
+    next_item = your_true_benefits[len(your_past_benefits)].upper()
+    
+    # handle the "other" case specially
+    if next_item == "OTHER":
+      your_past_benefits.new_item_name = past_other_benefit
+    else:
+      your_past_benefits.new_item_name = next_item
+    
+    # say that we expect another field (will ask for necessary fields)
+    your_past_benefits.there_is_another = True
+  else:
+    # say that no more fields are needed
+    your_past_benefits.there_is_another = False
+---
+code: |
+  if len(your_children_past_benefits) < len(your_children_true_benefits):
+    next_item = your_children_true_benefits[len(your_children_past_benefits)].upper()
+    
+    if next_item == "ANOTHER":
+      your_children_past_benefits.new_item_name = past_child_other_benefit
+    else:
+      your_children_past_benefits.new_item_name = next_item
+    
+    your_children_past_benefits.there_is_another = True
+  else:
+    your_children_past_benefits.there_is_another = False
+---
+question: |
+  Do you or your children get government need-based benefits?
+fields:
+  - "I get a needs-based benefit": benefits
+    datatype: yesnoradio
+  - "I get": income_items_list
+    show if: benefits
+    datatype: checkboxes
+    choices:
+      - SSI: ssi
+      - TAFDC: tafdc
+      - EAEDC: eaedc
+      - another benefit: other
+    none of the above: False
+  - "What other benefit or benefits do you get?": other_benefit
+    js show if: |
+       val("benefits") && val("income_items_list['other']")
+  - "I used to get a needs-based benefit": past_benefits
+    datatype: yesnoradio
+  - "I used to get": past_income_items_list
+    show if: past_benefits
+    datatype: checkboxes
+    choices:
+      - SSI: ssi
+      - TAFDC: tafdc
+      - EAEDC: eaedc
+      - another benefit: other
+    none of the above: False
+  - "What other benefit or benefits did you get?": past_other_benefit
+    js show if: |
+       val("past_benefits") && val("past_income_items_list['other']")
+  - "My child(ren) get(s) a needs-based benefit": child_benefits
+    datatype: yesnoradio
+  - "I get": child_income_items_list
+    show if: child_benefits
+    datatype: checkboxes
+    choices:
+      - SSI: ssi
+      - TAFDC: tafdc
+      - EAEDC: eaedc
+      - another benefit: other
+    none of the above: False
+  - "What other benefit or benefits do you get?": child_other_benefit
+    js show if: |
+       val("child_benefits") && val("child_income_items_list['other']")
+  - "My child(ren) get(s) used to get a needs-based benefit": past_child_benefits
+    datatype: yesnoradio
+  - "They used to get": past_child_income_items_list
+    show if: past_child_benefits
+    datatype: checkboxes
+    choices:
+      - SSI: ssi
+      - TAFDC: tafdc
+      - EAEDC: eaedc
+      - another benefit: another
+    none of the above: False
+  - "What other benefit or benefits do you get?": past_child_other_benefit
+    js show if: |
+       val("past_child_benefits") && val('past_child_income_items_list["another"]')
+---
+question: |
+  Did DOR take money from your bank account when you were getting ${ i }?
+fields:
+  - no label: your_past_benefits[i].take_money
+    datatype: yesnoradio
+  - When did your ${ i } start?: your_past_benefits[i].start_date
+    datatype: date
+    show if: your_past_benefits[i].take_money
+  - When did your ${ i } end?: your_past_benefits[i].end_date
+    datatype: date
+    show if: your_past_benefits[i].take_money
+---
+question: |
+  Did DOR take money from your bank account when your children were getting ${ i }?
+fields:
+  - no label: your_children_past_benefits[i].take_money
+    datatype: yesnoradio
+  - When did your ${ i } start?: your_children_past_benefits[i].start_date
+    datatype: date
+    show if: your_children_past_benefits[i].take_money
+  - When did your ${ i } end?: your_children_past_benefits[i].end_date
+    datatype: date
+    show if: your_children_past_benefits[i].take_money
+---
+question: |
+  Hi
+subquestion: |
+  Your past benefits:
+  % for item in your_past_benefits:
+  ${ item } : ${ your_past_benefits[item].take_money }
+  % endfor
+  
+  Your children's past benefits
+  % for item in your_children_past_benefits:
+  ${ item } : ${ your_children_past_benefits[item].take_money }
+  % endfor
+field: hi

--- a/docassemble/DeadBrokeDads/data/questions/DBD-test.yml
+++ b/docassemble/DeadBrokeDads/data/questions/DBD-test.yml
@@ -1,9 +1,13 @@
 objects:
+  - benefits_dor_took_money: DAObject
   - your_past_benefits: DADict.using(object_type=DAObject)
   - your_children_past_benefits: DADict.using(object_type=DAObject)
 ---
 mandatory: True
 code: |
+  benefits_dor_took_money.initializeAttribute("yours", DAList.using(there_are_any=False))
+  benefits_dor_took_money.initializeAttribute("childrens", DAList.using(there_are_any=False))
+  
   # get a static income list
   your_true_benefits = your_income_list.true_values()
   
@@ -21,8 +25,6 @@ code: |
       else:
         benefit.end = benefit.end_date
 
-        
-
   # same as above
   your_children_true_benefits = your_children_income_list.true_values()
   your_children_past_benefits.there_are_any = len(your_children_true_benefits) > 0
@@ -36,20 +38,11 @@ code: |
         benefit.end = today()
       else:
         benefit.end = benefit.end_date
- 
-  if dor_took_money:
-    took_money_matches_time = False
-    
-    # find if the date is in range for your benefits
-    for benefit in your_past_benefits.values():
-      # not sure if end date is inclusive (it counts) or exclusive (it doesn't)
-      if benefit.start_date <= dor_took_money_date <= benefit.end:
-        took_money_matches_time = True
 
-    # find if the date is in range for your child(ren)'s benefits
-    for benefit in your_children_past_benefits.values():
-      if benefit.start_date <= dor_took_money_date <= benefit.end:
-        took_money_matches_time = True    
+  if dor_took_money:
+    # these parts have to be separate code blocks, otherwise docassemble does some weird stuff (such as duplicating the first list)
+    benefits_dor_took_money.yours.gathered
+    benefits_dor_took_money.childrens.gathered
   hi
 ---
 code: |
@@ -73,6 +66,26 @@ code: |
     your_children_past_benefits.there_is_another = True
   else:
     your_children_past_benefits.there_is_another = False
+---
+code: |
+  for item in your_past_benefits:
+    benefit = your_past_benefits[item]
+    
+    # not sure if end date is inclusive (it counts) or exclusive (it doesn't)
+    if benefit.start_date <= dor_took_money_date <= benefit.end:
+      benefits_dor_took_money.yours.append(item)
+
+  benefits_dor_took_money.yours.gathered = True
+---
+code: |
+  # find if the date is in range for your child(ren)'s benefits
+  for item in your_children_past_benefits:
+    benefit = your_children_past_benefits[item]
+    
+    if benefit.start_date <= dor_took_money_date <= benefit.end:
+      benefits_dor_took_money.childrens.append(item)  
+
+  benefits_dor_took_money.childrens.gathered = True
 ---
 question: |
   Did you ever get any of these benefits?
@@ -146,8 +159,12 @@ subquestion: |
   ### DOR Notice
   You said DOR took money from your bank ${ dor_took_money_date }.
   
-    % if took_money_matches_time:
-    DOR took money from your account while you were receiving a benefit.
+    % if len(benefits_dor_took_money.yours) > 0:
+    DOR took money from you while you were receiving the following ${ "benefit" if len(benefits_dor_took_money.yours) == 1 else "benefits" }: ${ benefits_dor_took_money.yours }
+    % endif
+    
+    % if len(benefits_dor_took_money.childrens) > 0:
+    DOR took money from you while your children were receiving the following ${ "benefit" if len(benefits_dor_took_money.childrens) == 1 else "benefits" }: ${ benefits_dor_took_money.childrens }
     % endif
   % endif
   

--- a/docassemble/DeadBrokeDads/data/questions/DBD-test.yml
+++ b/docassemble/DeadBrokeDads/data/questions/DBD-test.yml
@@ -4,22 +4,15 @@ objects:
 ---
 mandatory: True
 code: |
-  if past_benefits:
-    # get a list of true benefits; we save this so the order is the same
-    your_true_benefits = past_income_items_list.true_values()
-    
-    # say that there are benefits (forces asking questions)
-    your_past_benefits.there_are_any = True
-  else:
-    # no past benefits, the dictionary should be empty
-    your_past_benefits.there_are_any = False
+  # get a static income list
+  your_true_benefits = your_income_list.true_values()
   
+  # only ask about benefits if any listed
+  your_past_benefits.there_are_any = len(your_true_benefits) > 0
+
   # same as above
-  if past_child_benefits:
-    your_children_true_benefits = past_child_income_items_list.true_values()
-    your_children_past_benefits.there_are_any = True
-  else:
-    your_children_past_benefits.there_are_any = False
+  your_children_true_benefits = your_children_income_list.true_values()
+  your_children_past_benefits.there_are_any = len(your_children_true_benefits) > 0
     
   hi
 ---
@@ -30,15 +23,10 @@ code: |
   
   if len(your_past_benefits) < len(your_true_benefits):
     next_item = your_true_benefits[len(your_past_benefits)].upper()
-    
-    # handle the "other" case specially
-    if next_item == "OTHER":
-      your_past_benefits.new_item_name = past_other_benefit
-    else:
-      your_past_benefits.new_item_name = next_item
+    your_past_benefits.new_item_name = next_item
     
     # say that we expect another field (will ask for necessary fields)
-    your_past_benefits.there_is_another = True
+    your_past_benefits.there_is_another = True      
   else:
     # say that no more fields are needed
     your_past_benefits.there_is_another = False
@@ -46,106 +34,76 @@ code: |
 code: |
   if len(your_children_past_benefits) < len(your_children_true_benefits):
     next_item = your_children_true_benefits[len(your_children_past_benefits)].upper()
-    
-    if next_item == "ANOTHER":
-      your_children_past_benefits.new_item_name = past_child_other_benefit
-    else:
-      your_children_past_benefits.new_item_name = next_item
+    your_children_past_benefits.new_item_name = next_item
     
     your_children_past_benefits.there_is_another = True
   else:
     your_children_past_benefits.there_is_another = False
 ---
 question: |
-  Do you or your children get government need-based benefits?
+  Did you ever get any of these benefits?
 fields:
-  - "I get a needs-based benefit": benefits
-    datatype: yesnoradio
-  - "I get": income_items_list
-    show if: benefits
+  - no label: your_income_list
     datatype: checkboxes
     choices:
       - SSI: ssi
       - TAFDC: tafdc
       - EAEDC: eaedc
-      - another benefit: other
-    none of the above: False
-  - "What other benefit or benefits do you get?": other_benefit
-    js show if: |
-       val("benefits") && val("income_items_list['other']")
-  - "I used to get a needs-based benefit": past_benefits
-    datatype: yesnoradio
-  - "I used to get": past_income_items_list
-    show if: past_benefits
-    datatype: checkboxes
-    choices:
-      - SSI: ssi
-      - TAFDC: tafdc
-      - EAEDC: eaedc
-      - another benefit: other
-    none of the above: False
-  - "What other benefit or benefits did you get?": past_other_benefit
-    js show if: |
-       val("past_benefits") && val("past_income_items_list['other']")
-  - "My child(ren) get(s) a needs-based benefit": child_benefits
-    datatype: yesnoradio
-  - "I get": child_income_items_list
-    show if: child_benefits
-    datatype: checkboxes
-    choices:
-      - SSI: ssi
-      - TAFDC: tafdc
-      - EAEDC: eaedc
-      - another benefit: other
-    none of the above: False
-  - "What other benefit or benefits do you get?": child_other_benefit
-    js show if: |
-       val("child_benefits") && val("child_income_items_list['other']")
-  - "My child(ren) get(s) used to get a needs-based benefit": past_child_benefits
-    datatype: yesnoradio
-  - "They used to get": past_child_income_items_list
-    show if: past_child_benefits
-    datatype: checkboxes
-    choices:
-      - SSI: ssi
-      - TAFDC: tafdc
-      - EAEDC: eaedc
-      - another benefit: another
-    none of the above: False
-  - "What other benefit or benefits do you get?": past_child_other_benefit
-    js show if: |
-       val("past_child_benefits") && val('past_child_income_items_list["another"]')
 ---
+question: |
+  About your ${ i } benefit
+fields:
+  - When did your ${ i } start?: your_past_benefits[i].start_date
+    datatype: date
+  - Are you still receiving ${ i }?: your_past_benefits[i].still_receiving
+    datatype: yesnoradio
+  - When did your ${ i } end?: your_past_benefits[i].end_date
+    datatype: date
+    js show if: |
+      val("your_past_benefits[i].still_receiving") === false
+---
+need: your_past_benefits[i].start_date
 question: |
   Did DOR take money from your bank account when you were getting ${ i }?
 fields:
   - no label: your_past_benefits[i].take_money
     datatype: yesnoradio
-  - When did your ${ i } start?: your_past_benefits[i].start_date
-    datatype: date
-    show if: your_past_benefits[i].take_money
-  - When did your ${ i } end?: your_past_benefits[i].end_date
-    datatype: date
-    show if: your_past_benefits[i].take_money
 ---
+question: |
+  Did your children ever get any of these benefits?
+fields:
+  - no label: your_children_income_list
+    datatype: checkboxes
+    choices:
+      - SSI: ssi
+      - TAFDC: tafdc
+      - EAEDC: eaedc
+---
+question: |
+  About your child(ren)'s ${ i } benefit
+fields:
+  - When did your ${ i } start?: your_children_past_benefits[i].start_date
+    datatype: date
+  - Are you still receiving ${ i }?: your_children_past_benefits[i].still_receiving
+    datatype: yesnoradio
+  - When did your ${ i } end?: your_children_past_benefits[i].end_date
+    datatype: date
+    js show if: |
+      val("your_children_past_benefits[i].still_receiving") === false
+---
+need: your_children_past_benefits[i].start_date
 question: |
   Did DOR take money from your bank account when your children were getting ${ i }?
 fields:
   - no label: your_children_past_benefits[i].take_money
     datatype: yesnoradio
-  - When did your ${ i } start?: your_children_past_benefits[i].start_date
-    datatype: date
-    show if: your_children_past_benefits[i].take_money
-  - When did your ${ i } end?: your_children_past_benefits[i].end_date
-    datatype: date
-    show if: your_children_past_benefits[i].take_money
 ---
 question: |
   Hi
 subquestion: |
   Your past benefits:
   % for item in your_past_benefits:
-  ${ item } : ${ your_past_benefits[item].take_money }
+  ${ item } : ${ your_past_benefits[item].take_money }, ${ your_past_benefits[item].start_date }
   % endfor
   
   Your children's past benefits


### PR DESCRIPTION
The new file (DBD-test.yml) demos how to ask the same question for different benefits while constructing a dictionary. It also addresses a subtle bug . Previously, you could have "benefits" unchecked, but checked "other" before, and the "other question" field would be visible.